### PR TITLE
removing GPL licence header from gpc.cpp and gpc.h

### DIFF
--- a/src/gpc/gpc.cpp
+++ b/src/gpc/gpc.cpp
@@ -1,19 +1,5 @@
 /* GPC: A library for the solution of General Point Correspondence problems.
   Copyright (C) 2006 Andrea Censi (andrea at censi dot org)
-
-  This program is free software; you can redistribute it and/or
-  modify it under the terms of the GNU General Public License
-  as published by the Free Software Foundation; either version 2
-  of the License, or (at your option) any later version.
-
-  This program is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  GNU General Public License for more details.
-
-  You should have received a copy of the GNU General Public License
-  along with this program; if not, write to the Free Software
-  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 */
 
 #include <math.h>

--- a/src/gpc/gpc.h
+++ b/src/gpc/gpc.h
@@ -1,20 +1,6 @@
 /*
 // GPC: A library for the solution of General Point Correspondence problems.
 // Copyright (C) 2006 Andrea Censi (andrea at censi dot org)
-
-// This program is free software; you can redistribute it and/or
-// modify it under the terms of the GNU General Public License
-// as published by the Free Software Foundation; either version 2
-// of the License, or (at your option) any later version.
-
-// This program is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-
-// You should have received a copy of the GNU General Public License
-// along with this program; if not, write to the Free Software
-// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 */
 
 #ifndef H_GENERAL_POINT_CORRESPONDENCE


### PR DESCRIPTION
I guess it is better if you confirm the removal of the GPL license header from gpc.h/cpp yourself.
