### PR TITLE
fix linking of debug build

### DIFF
--- a/src/csm/math_utils_gsl.h
+++ b/src/csm/math_utils_gsl.h
@@ -33,7 +33,7 @@
 
 /** Returns Fisher's information matrix. You still have to multiply
     it by (1/sigma^2). */
-val ld_fisher0(LDP ld);
+//val ld_fisher0(LDP ld);
 
 
 #endif

--- a/src/icp/icp.cpp
+++ b/src/icp/icp.cpp
@@ -155,15 +155,15 @@ void sm_icp(struct sm_params*params, struct sm_result*res) {
 			res->dx_dy1_m = egsl_v2gslm(dx_dy1);
 			res->dx_dy2_m = egsl_v2gslm(dx_dy2);
 		
-			if(0) {
+			//if(0) {
 				//egsl_print("cov0_x", cov0_x);
 				//egsl_print_spectrum("cov0_x", cov0_x);
 		
-				val fim = ld_fisher0(laser_ref);
-				egsl_print("fim", fim);
+				//val fim = ld_fisher0(laser_ref);
+				//egsl_print("fim", fim);
 				//val ifim = inv(fim);
 				//egsl_print_spectrum("ifim", ifim);
-			}
+			//}
 		}
 	
 		res->error = best_error;


### PR DESCRIPTION
ld_fisher0 was not implemented but it showed up in a deactivated if
statement. This caused a linking error in unoptimized builds, i.e.,
debug builds. I commented the declaration and the corresponding if.