### PR TITLE
Add a package manifesto file for ROS release

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<package>
+  <name>csm</name>
+  <version>1.0.0</version>
+  <description>
+    This is a ROS 3rd-party wrapper <a href = "http://www.ros.org/reps/rep-0136.html">(see REP-136 for more detail)</a> of Andrea Censi's CSM package. 
+
+    From <a href = "http://censi.mit.edu/software/csm/">the official website</a>:
+    <ul>
+      The C(anonical) Scan Matcher (CSM) is a pure C implementation of a very fast variation of ICP using a point-to-line metric optimized for range-finder scan matching.
+
+      It is robust enough to be used in industrial prototypes of autonomous mobile robotics, for example at Kuka. CSM is used by a variety of people, though it is hard to keep track because of the open source distribution, especially as packaged in ROS. If you use this software for something cool, let me know.
+    </ul>
+  </description>
+
+  <author>Andrea Censi</author>
+  <license>LGPL</license>
+
+  <url type="website">http://censi.mit.edu/software/csm</url>
+  <url type="website">http://wiki.ros.org/csm</url>
+  <url type="repository">https://github.com/AndreaCensi/csm</url>
+  <url type="bugtracker">https://github.com/AndreaCensi/csm/issues</url>
+  <maintainer email="130s@2000.jukuin.keio.ac.jp">Isaac I.Y. Saito</maintainer>
+
+  <buildtool_depend>cmake</buildtool_depend>
+  <run_depend>catkin</run_depend>
+  <export />
+</package>


### PR DESCRIPTION
Dear @AndreaCensi,

I recently took over a maintainership of `laser_scan_matcher`, the ROS package of your fabulous CSM, and tried to make a "release" (creating .DEB package for Ubuntu that's installable via a single apt-get command). Unfortunately ROS facility might not be permissible of the way currently laser_scan_matcher builds CSM (i.e. downloading source code of CSM during build process). 

Simple solution to it is to inject a single manifesto file into your repository, which is what I'm doing with this pull request. The file "`package.xml`" should NOT influence any usage of your package at all. I've also set the version (ROS requires it) as 1.0.0, without knowing CSM is already versioned.

You will have no obligation to this change, other than just reviewing and accepting this pull request.

If you're interested, the rationale of this injection is <s>formerly</s>formally documented on ROS website: http://www.ros.org/reps/rep-0136.html

Thank you again for the great feature and cooperation.
Isaac Saito