### PR TITLE
Add a package manifesto and cmake rule for ROS release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,5 @@
+## This CMakeLists.txt file exists only for building as ROS 3rd-party package. Building for other purpose is not tested. See https://github.com/AndreaCensi/csm/pull/10
+cmake_minimum_required(VERSION 2.8)
+project(csm)
+
+INSTALL(FILES package.xml DESTINATION share/csm)

--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<package>
+  <name>csm</name>
+  <version>1.0.0</version>
+  <description>
+    This is a ROS 3rd-party wrapper <a href = "http://www.ros.org/reps/rep-0136.html">(see REP-136 for more detail)</a> of Andrea Censi's CSM package. 
+
+    From <a href = "http://censi.mit.edu/software/csm/">the official website</a>:
+    <ul>
+      The C(anonical) Scan Matcher (CSM) is a pure C implementation of a very fast variation of ICP using a point-to-line metric optimized for range-finder scan matching.
+
+      It is robust enough to be used in industrial prototypes of autonomous mobile robotics, for example at Kuka. CSM is used by a variety of people, though it is hard to keep track because of the open source distribution, especially as packaged in ROS. If you use this software for something cool, let me know.
+    </ul>
+  </description>
+
+  <author>Andrea Censi</author>
+  <license>LGPL</license>
+
+  <url type="website">http://censi.mit.edu/software/csm</url>
+  <url type="website">http://wiki.ros.org/csm</url>
+  <url type="repository">https://github.com/AndreaCensi/csm</url>
+  <url type="bugtracker">https://github.com/AndreaCensi/csm/issues</url>
+  <maintainer email="130s@2000.jukuin.keio.ac.jp">Isaac I.Y. Saito</maintainer>
+
+  <buildtool_depend>cmake</buildtool_depend>
+  <run_depend>catkin</run_depend>
+  <export>
+    <build_type>cmake</build_type>
+  </export>
+</package>


### PR DESCRIPTION
Similar to https://github.com/AndreaCensi/csm/pull/10 but different in that:
- this is against `csm_eigen` branch
- One more file added: a simple `CMakeLists.txt` that I found is also a requirement for ROS release. Hope this won't affect how existing users of this branch