### PR TITLE
Version increment to 1.0.1

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package>
   <name>csm</name>
-  <version>1.0.0</version>
+  <version>1.0.1</version>
   <description>
     This is a ROS 3rd-party wrapper <a href = "http://www.ros.org/reps/rep-0136.html">(see REP-136 for more detail)</a> of Andrea Censi's CSM package. 
 


### PR DESCRIPTION
Sorry for the noise. 

I just made a release tag 1.0.0, which was done before #11 was merged. So let me increment to 1.0.1 to try it out again...