### PR TITLE
Corrected min and max macros defined in bits.h

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,24 @@
-For more information about the C(anonical) Scan Matcher, see the webpage: http://purl.org/censi/2007/csm .
+Project forked from Andrea Censi github https://github.com/AndreaCensi/csm. For more info: http://purl.org/censi/2007/csm.
 
-This is the "master" branch of CSM, which uses GSL.
+## Changes
 
-There is also another branch, called [``csm_eigen``][branch], which uses the ``eigen`` library. 
-This branch is the work of people working at U. Freiburg and Kuka, including
-Christoph Sprunk and Rainer Kuemmerle.
+Corrected bug with 
+```
+#define min
+#define max
+```
+and applied modification suggested by David Mulero (less strict floating point precision).
 
-[branch]: https://github.com/AndreaCensi/csm/tree/csm_eigen
+## Compilation
 
-Binary install (via ROS)
-------------------------------
-
-(November 2015) Now you can install binary on Ubuntu (via ROS). As of today limited to Ubuntu Saucy and Trusty. To do so:
-
- 1. Add ROS repository to your Ubuntu's download site (For detail, see [ROS wiki](http://wiki.ros.org/indigo/Installation/Ubuntu)):
-
- ```
-sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list'
-sudo apt-key adv --keyserver hkp://pool.sks-keyservers.net --recv-key 0xB01FA116
-sudo apt-get update
+```
+mkdir build
+cd build
+cmake ../
+make
 ```
 
- 2. Install CSM. 
-
- ```
-sudo apt-get install ros-indigo-csm
+## Installation
 ```
-
-The package name contains "ROS" specific info, but you can use this as a standalone CSM library. It goes into these directory:
-
- ```
-/opt/ros/indigo/include/csm
-/opt/ros/indigo/lib/libcsm-static.a
-/opt/ros/indigo/lib/libcsm.so
+sudo make install
 ```

--- a/sm/csm/hsm/hsm.c
+++ b/sm/csm/hsm/hsm.c
@@ -141,7 +141,7 @@ void hsm_compute_spectrum(hsm_buffer b) {
 	for(int t=0; t<b->num_angular_cells; t++) {
 		b->hs[t] = 0;
 		for(int r=0;r<b->num_linear_cells;r++)
-			b->hs[t] = max(b->hs[t], b->ht[t][r]);
+			b->hs[t] = MAX(b->hs[t], b->ht[t][r]);
 	}
 }
 

--- a/sm/csm/hsm/hsm_interface.c
+++ b/sm/csm/hsm/hsm_interface.c
@@ -92,7 +92,7 @@ void sm_hsm(struct sm_params* params, struct sm_result* res) {
 	hsm_compute_spectrum(b1);
 	hsm_compute_spectrum(b2);
 
-	params->hsm.max_translation = max(b1->rho_max, b2->rho_max);
+	params->hsm.max_translation = MAX(b1->rho_max, b2->rho_max);
 	
 	hsm_match(&(params->hsm),b1,b2);
 

--- a/sm/csm/hsm/hsm_test00.c
+++ b/sm/csm/hsm/hsm_test00.c
@@ -76,7 +76,7 @@ int main(int argc, const char**argv) {
 	
 	
 	sm_debug("Doing scan-matching..\n"); 
-	p.hsmp.max_translation = max(b1->rho_max, b2->rho_max);
+	p.hsmp.max_translation = MAX(b1->rho_max, b2->rho_max);
 	
 	hsm_match(&(p.hsmp),b1,b2);
 

--- a/sm/csm/laser_data.c
+++ b/sm/csm/laser_data.c
@@ -200,12 +200,12 @@ int ld_valid_fields(LDP ld)  {
 		sm_error("Strange FOV: %f rad = %f deg \n", fov, rad2deg(fov));
 		return 0;
 	}
-	if(fabs(ld->min_theta - ld->theta[0]) > 1e-8) {
+	if(fabs(ld->min_theta - ld->theta[0]) > 1e-5) {
 		sm_error("Min_theta (%f) should be theta[0] (%f)\n",
 			ld->min_theta, ld->theta[0]);
 		return 0;
 	}
-	if(fabs(ld->max_theta - ld->theta[ld->nrays-1]) > 1e-8) {
+	if(fabs(ld->max_theta - ld->theta[ld->nrays-1]) > 1e-5) {
 		sm_error("Min_theta (%f) should be theta[0] (%f)\n",
 			ld->max_theta, ld->theta[ld->nrays-1]);
 		return 0;

--- a/sm/lib/json-c/arraylist.c
+++ b/sm/lib/json-c/arraylist.c
@@ -62,7 +62,7 @@ static int array_list_expand_internal(struct array_list *this, int max)
   int new_size;
 
   if(max < this->size) return 0;
-  new_size = max(this->size << 1, max);
+  new_size = MAX(this->size << 1, max);
   if(!(t = realloc(this->array, new_size*sizeof(void*)))) return -1;
   this->array = t;
   (void)memset(this->array + this->size, 0, (new_size-this->size)*sizeof(void*));

--- a/sm/lib/json-c/bits.h
+++ b/sm/lib/json-c/bits.h
@@ -12,12 +12,12 @@
 #ifndef _bits_h_
 #define _bits_h_
 
-#ifndef min
-#define min(a,b) ((a) < (b) ? (a) : (b))
+#ifndef MIN
+#define MIN(a,b) ((a) < (b) ? (a) : (b))
 #endif
 
-#ifndef max
-#define max(a,b) ((a) > (b) ? (a) : (b))
+#ifndef MAX
+#define MAX(a,b) ((a) > (b) ? (a) : (b))
 #endif
 
 #define hexdigit(x) (((x) <= '9') ? (x) - '0' : ((x) & 7) + 9)

--- a/sm/lib/json-c/json_tokener.c
+++ b/sm/lib/json-c/json_tokener.c
@@ -109,7 +109,7 @@ char* json_c_strndup(const char* str, size_t n)
 {
   if(str) {
     size_t len = strlen(str);
-    size_t nn = min(len,n);
+    size_t nn = MIN(len,n);
     char* s = (char*)malloc(sizeof(char) * (nn + 1));
 
     if(s) {
@@ -233,7 +233,7 @@ struct json_object* json_tokener_parse_ex(struct json_tokener *tok,
     case json_tokener_state_null:
       printbuf_memappend(tok->pb, &c, 1);
       if(strncasecmp(json_null_str, tok->pb->buf,
-		     min( (size_t) (tok->st_pos+1), strlen(json_null_str))) == 0) {
+		     MIN( (size_t) (tok->st_pos+1), strlen(json_null_str))) == 0) {
 	if(  ((size_t) tok->st_pos) == strlen(json_null_str)) {
 	  current = NULL;
 	  saved_state = json_tokener_state_finish;
@@ -354,7 +354,7 @@ struct json_object* json_tokener_parse_ex(struct json_tokener *tok,
     case json_tokener_state_boolean:
       printbuf_memappend(tok->pb, &c, 1);
       if(strncasecmp(json_true_str, tok->pb->buf,
-		      min( (size_t)(tok->st_pos+1), strlen(json_true_str))) == 0) {
+		      MIN( (size_t)(tok->st_pos+1), strlen(json_true_str))) == 0) {
 	if(((size_t) tok->st_pos) == strlen(json_true_str)) {
 	  current = json_object_new_boolean(1);
 	  saved_state = json_tokener_state_finish;
@@ -362,7 +362,7 @@ struct json_object* json_tokener_parse_ex(struct json_tokener *tok,
 	  goto redo_char;
 	}
       } else if(strncasecmp(json_false_str, tok->pb->buf,
-			    min((size_t)(tok->st_pos+1), strlen(json_false_str))) == 0) {
+			    MIN((size_t)(tok->st_pos+1), strlen(json_false_str))) == 0) {
 	if(( (size_t) tok->st_pos) == strlen(json_false_str)) {
 	  current = json_object_new_boolean(0);
 	  saved_state = json_tokener_state_finish;

--- a/sm/lib/json-c/printbuf.c
+++ b/sm/lib/json-c/printbuf.c
@@ -44,7 +44,7 @@ int printbuf_memappend(struct printbuf *p, const char *buf, int size)
 {
   char *t;
   if(p->size - p->bpos <= size) {
-    int new_size = max(p->size * 2, p->bpos + size + 8);
+    int new_size = MAX(p->size * 2, p->bpos + size + 8);
 #ifdef PRINTBUF_DEBUG
     mc_debug("printbuf_memappend: realloc "
 	     "bpos=%d wrsize=%d old_size=%d new_size=%d\n",


### PR DESCRIPTION
Corrected min and max macros defined in bits.h Should be defined with capital letters to prevent collisions with standard C++ libraries (and many others).