### PR TITLE
Fix ROS builds

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -22,7 +22,11 @@
   <url type="bugtracker">https://github.com/AndreaCensi/csm/issues</url>
   <maintainer email="130s@2000.jukuin.keio.ac.jp">Isaac I.Y. Saito</maintainer>
 
-  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend>cmake</buildtool_depend>
+  <buildtool_depend>pkg-config</buildtool_depend>
+  <build_depend>libcairo2-dev</build_depend>
   <build_depend>libgsl</build_depend>
-  <export />
+  <export>
+    <build_type>cmake</build_type>
+  </export>
 </package>


### PR DESCRIPTION
This packge is not a catkin package - there is no mention of catkin in the `CMakeLists.txt`. Catkin can still build the package if it is a 'plain cmake' package, as indicated by the `build_type`.

Also, the Cairo dependency was missing.

The `package.xml` should really be installed to the share directory as well, so that when this package is installed, rosdep can see it.