### PR TITLE
Add missing feature macros

### DIFF
--- a/sm/CMakeLists.txt
+++ b/sm/CMakeLists.txt
@@ -57,7 +57,10 @@ MESSAGE(STATUS "csm_link_flags = ${csm_link_flags}")
 
 SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${csm_c_flags}")
 SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99")
-SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC -ggdb -Wall")
+SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC -ggdb -Wall -Werror=implicit-function-declaration")
+# _DEFAULT_SOURCE and _GNU_SOURCE will enable some function we are checking for
+# with CHECK_FUNCTION_EXISTS (vsyslog, ...) and some we are using without checking for, like strdup.
+SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D_DEFAULT_SOURCE -D_GNU_SOURCE")
 
 
 # for realpath


### PR DESCRIPTION
We were using some functions (like strdup) without defining the required feature
macros. For instance, strdup requires `_POSIX_C_SOURCE >= 200809L`, and
vasprintf _GNU_SOURCE. This was causing some SEGFAULT because the functions were
assumed to have the signature `int f()`, but returned something of a different size (as strdup).

Fix this by defining `_DEFAULT_SOURCE` (which defines `_POSIX_C_SOURCE >=
200809L`) and `_GNU_SOURCE`.

Note: this should not impact the system that doesn't have the impacted functions for the functions we check with `CHECK_FUNCTION_EXISTS`.